### PR TITLE
allow pip to find pre-built cryptography version, currently its error…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ certbot==1.14.0
 certbot-dns-route53==1.14.0
 click==7.1.2
 configobj==5.0.6
-cryptography==3.4.7
+cryptography
 dynaconf==3.1.4
 hvac==0.10.9
 jinja2==2.11.3


### PR DESCRIPTION
…ing out trying to build from source